### PR TITLE
Removed unnecessary imports

### DIFF
--- a/hackerrank/HackerRankAPI.py
+++ b/hackerrank/HackerRankAPI.py
@@ -1,8 +1,6 @@
 from __future__ import print_function 
 import requests
 import json
-from settings import RUN_API_ENDPOINT
-from settings import LANG_CODE
 
 #Hackerrank API endpoint
 RUN_API_ENDPOINT = 'http://api.hackerrank.com/checker/submission.json'


### PR DESCRIPTION
from settings import RUN_API_ENDPOINT
from settings import LANG_CODE

Above Imports causes ImportError when package installed from pypi.
RUN_API_ENDPOINT and LANG_CODE already defined in HackerRankAPI.py